### PR TITLE
Fix editable GLSL text boxes

### DIFF
--- a/propertytable/contextmenu.js
+++ b/propertytable/contextmenu.js
@@ -319,6 +319,8 @@ function _addStringControls(pane, binding, options) {
     if (options.multiline) {
         pane.addBinding(options, "wordwrap", { label: 'Word Wrap' })
             .on('change', () => binding.update());
+        pane.addBinding(options, "scrollbars", { label: 'Scrollbars' })
+            .on('change', () => binding.update());
     }
 }
 

--- a/propertytable/highlighter.js
+++ b/propertytable/highlighter.js
@@ -271,16 +271,17 @@ const textareaHighlighters = new WeakMap();
  * @param {Object} options - Configuration options
  * @param {boolean} options.wordwrap - Enable word wrapping
  * @param {string} options.highlighting - Type of syntax highlighting ('glsl', etc.)
+ * @param {boolean} options.scrollbars - Show scrollbars
  */
 export function setTextareaStyle(textarea, options = {}) {
     if (!textarea || !(textarea instanceof HTMLTextAreaElement)) {
         throw new Error('Invalid textarea element provided');
     }
 
-    const { wordwrap, highlighting } = options;
+    const { wordwrap, highlighting, scrollbars } = options;
 
     // Apply base styling
-    _applyBaseStyles(textarea);
+    _applyBaseStyles(textarea, scrollbars);
     
     // Apply word wrap settings
     _applyWordWrapStyles(textarea, wordwrap);
@@ -294,8 +295,10 @@ export function setTextareaStyle(textarea, options = {}) {
     }
 }
 
-function _applyBaseStyles(textarea) {
-    Object.assign(textarea.style, HIGHLIGHTER_CONFIG.BASE_TEXTAREA_STYLES);
+function _applyBaseStyles(textarea, scrollbars) {
+    Object.assign(textarea.style, HIGHLIGHTER_CONFIG.BASE_TEXTAREA_STYLES, {
+        overflow: scrollbars ? 'auto' : 'hidden'
+    });
 }
 
 function _applyWordWrapStyles(textarea, wordwrap) {

--- a/propertytable/propertytable.js
+++ b/propertytable/propertytable.js
@@ -38,7 +38,8 @@ class PropertyTable extends Pane {
             NUMBER_MIN: 0,
             NUMBER_MAX: 100,
             TYPE_VALUES: ["text here", 0.0, { x: 0, y: 0 }, { x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 0 }, false],
-            TYPE_OPTIONS: { string: 0, float: 1, vec2: 2, vec3: 3, vec4: 4, boolean: 5 }
+            TYPE_OPTIONS: { string: 0, float: 1, vec2: 2, vec3: 3, vec4: 4, boolean: 5 },
+            SCROLLBARS: true
         },
         OPACITY: {
             HOVER: '1',
@@ -79,6 +80,9 @@ class PropertyTable extends Pane {
                 if (options.multiline) {
                     options.readonly = true; // force to switch log control (which uses textarea)  for multiline strings
                     options.wordwrap = true;
+                    if (options.scrollbars === undefined) {
+                        options.scrollbars = PropertyTable.CONSTANTS.DEFAULT_VALUES.SCROLLBARS;
+                    }
                 }
                 break;
             }
@@ -108,7 +112,10 @@ class PropertyTable extends Pane {
                             
                             const textarea = element?.querySelector('textarea');
                             if (textarea) {
+                                textarea.readOnly = false;
                                 setTextareaStyle(textarea, options);
+                                const ticker = binding.controller?.value?.ticker;
+                                ticker?.dispose?.();
                                 textarea.addEventListener('input', (e) => target[property] = e.target.value);
                                 binding.update = () => setTextareaStyle(textarea, options);
                             }


### PR DESCRIPTION
## Summary
- stop monitor refresh so GLSL text boxes stay editable
- allow scrollbars via new option
- update context menu to toggle scrollbars
- support scrollbars in `setTextareaStyle`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e2330d680832984b658b046f0c052